### PR TITLE
Make device-based build images start from balena build images

### DIFF
--- a/Dockerfiles/architecture-base/aarch64/ubuntu/bionic/4.2.3/run/Dockerfile
+++ b/Dockerfiles/architecture-base/aarch64/ubuntu/bionic/4.2.3/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/aarch64-ubuntu-swift:4.2.3-bionic-run
 
-ARG BASE_IMAGE=balenalib/aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/aarch64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/aarch64/ubuntu/bionic/5.0.1/run/Dockerfile
+++ b/Dockerfiles/architecture-base/aarch64/ubuntu/bionic/5.0.1/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/aarch64-ubuntu-swift:5.0.1-bionic-run
 
-ARG BASE_IMAGE=balenalib/aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/aarch64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/aarch64/ubuntu/bionic/5.0/run/Dockerfile
+++ b/Dockerfiles/architecture-base/aarch64/ubuntu/bionic/5.0/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/aarch64-ubuntu-swift:5.0-bionic-run
 
-ARG BASE_IMAGE=balenalib/aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/aarch64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/aarch64/ubuntu/xenial/4.2.3/run/Dockerfile
+++ b/Dockerfiles/architecture-base/aarch64/ubuntu/xenial/4.2.3/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/aarch64-ubuntu-swift:4.2.3-xenial-run
 
-ARG BASE_IMAGE=balenalib/aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/aarch64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/aarch64/ubuntu/xenial/5.0.1/run/Dockerfile
+++ b/Dockerfiles/architecture-base/aarch64/ubuntu/xenial/5.0.1/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/aarch64-ubuntu-swift:5.0.1-xenial-run
 
-ARG BASE_IMAGE=balenalib/aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/aarch64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/aarch64/ubuntu/xenial/5.0/run/Dockerfile
+++ b/Dockerfiles/architecture-base/aarch64/ubuntu/xenial/5.0/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/aarch64-ubuntu-swift:5.0-xenial-run
 
-ARG BASE_IMAGE=balenalib/aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/aarch64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/debian/stretch/4.2.3/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/debian/stretch/4.2.3/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-debian-swift:4.2.3-stretch-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-debian:stretch
+ARG BASE_IMAGE=balenalib/armv7hf-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/debian/stretch/5.0.1/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/debian/stretch/5.0.1/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-debian-swift:5.0.1-stretch-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-debian:stretch
+ARG BASE_IMAGE=balenalib/armv7hf-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/debian/stretch/5.0/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/debian/stretch/5.0/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-debian-swift:5.0-stretch-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-debian:stretch
+ARG BASE_IMAGE=balenalib/armv7hf-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/ubuntu/bionic/4.2.3/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/ubuntu/bionic/4.2.3/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-ubuntu-swift:4.2.3-bionic-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/ubuntu/bionic/5.0.1/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/ubuntu/bionic/5.0.1/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-ubuntu-swift:5.0.1-bionic-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/ubuntu/bionic/5.0/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/ubuntu/bionic/5.0/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-ubuntu-swift:5.0-bionic-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/ubuntu/xenial/4.2.3/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/ubuntu/xenial/4.2.3/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-ubuntu-swift:4.2.3-xenial-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/ubuntu/xenial/5.0.1/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/ubuntu/xenial/5.0.1/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-ubuntu-swift:5.0.1-xenial-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/armv7hf/ubuntu/xenial/5.0/run/Dockerfile
+++ b/Dockerfiles/architecture-base/armv7hf/ubuntu/xenial/5.0/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/armv7hf-ubuntu-swift:5.0-xenial-run
 
-ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/armv7hf-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/rpi/debian/stretch/4.2.3/run/Dockerfile
+++ b/Dockerfiles/architecture-base/rpi/debian/stretch/4.2.3/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/rpi-debian-swift:4.2.3-stretch-run
 
-ARG BASE_IMAGE=balenalib/rpi-debian:stretch
+ARG BASE_IMAGE=balenalib/rpi-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/rpi/debian/stretch/5.0.1/run/Dockerfile
+++ b/Dockerfiles/architecture-base/rpi/debian/stretch/5.0.1/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/rpi-debian-swift:5.0.1-stretch-run
 
-ARG BASE_IMAGE=balenalib/rpi-debian:stretch
+ARG BASE_IMAGE=balenalib/rpi-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/architecture-base/rpi/debian/stretch/5.0/run/Dockerfile
+++ b/Dockerfiles/architecture-base/rpi/debian/stretch/5.0/run/Dockerfile
@@ -1,6 +1,6 @@
 # wlisac/rpi-debian-swift:5.0-stretch-run
 
-ARG BASE_IMAGE=balenalib/rpi-debian:stretch
+ARG BASE_IMAGE=balenalib/rpi-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -20,7 +20,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:4.2.3-bionic-build
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:4.2.3-bionic-run
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:5.0.1-bionic-build
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:5.0.1-bionic-run
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:5.0-bionic-build
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:5.0-bionic-run
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:4.2.3-xenial-build
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:4.2.3-xenial-run
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:5.0.1-xenial-build
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:5.0.1-xenial-run
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:5.0-xenial-build
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-aarch64-ubuntu-swift:5.0-xenial-run
 
-ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-aarch64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-debian-swift:4.2.3-stretch-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-debian-swift:4.2.3-stretch-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-debian-swift:5.0.1-stretch-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-debian-swift:5.0.1-stretch-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-debian-swift:5.0-stretch-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/debian/stretch/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-debian-swift:5.0-stretch-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:4.2.3-bionic-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:4.2.3-bionic-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:5.0.1-bionic-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:5.0.1-bionic-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:5.0-bionic-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/bionic/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:5.0-bionic-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:4.2.3-xenial-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:4.2.3-xenial-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:5.0.1-xenial-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:5.0.1-xenial-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:5.0-xenial-build
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/generic-armv7ahf/ubuntu/xenial/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/generic-armv7ahf-ubuntu-swift:5.0-xenial-run
 
-ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/generic-armv7ahf-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi/debian/stretch/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi/debian/stretch/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi-debian-swift:4.2.3-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi/debian/stretch/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi/debian/stretch/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi-debian-swift:4.2.3-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi/debian/stretch/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi/debian/stretch/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi-debian-swift:5.0.1-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi/debian/stretch/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi/debian/stretch/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi-debian-swift:5.0.1-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi/debian/stretch/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi/debian/stretch/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi-debian-swift:5.0-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi/debian/stretch/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi/debian/stretch/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi-debian-swift:5.0-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/debian/stretch/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/debian/stretch/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-debian-swift:4.2.3-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/debian/stretch/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/debian/stretch/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-debian-swift:4.2.3-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/debian/stretch/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/debian/stretch/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-debian-swift:5.0.1-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/debian/stretch/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/debian/stretch/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-debian-swift:5.0.1-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/debian/stretch/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/debian/stretch/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-debian-swift:5.0-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/debian/stretch/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/debian/stretch/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-debian-swift:5.0-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberry-pi2-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:4.2.3-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:4.2.3-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:5.0.1-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:5.0.1-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:5.0-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/bionic/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:5.0-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:4.2.3-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:4.2.3-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:5.0.1-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:5.0.1-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:5.0-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberry-pi2/ubuntu/xenial/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberry-pi2-ubuntu-swift:5.0-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberry-pi2-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:4.2.3-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:4.2.3-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:5.0.1-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:5.0.1-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:5.0-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:5.0-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:4.2.3-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:4.2.3-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:5.0.1-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:5.0.1-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:5.0-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-64-ubuntu-swift:5.0-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-64-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/debian/stretch/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/debian/stretch/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-debian-swift:4.2.3-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/debian/stretch/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/debian/stretch/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-debian-swift:4.2.3-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/debian/stretch/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/debian/stretch/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-debian-swift:5.0.1-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/debian/stretch/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/debian/stretch/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-debian-swift:5.0.1-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/debian/stretch/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/debian/stretch/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-debian-swift:5.0-stretch-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/debian/stretch/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/debian/stretch/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-debian-swift:5.0-stretch-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch
+ARG BASE_IMAGE=balenalib/raspberrypi3-debian:stretch-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:4.2.3-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:4.2.3-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:5.0.1-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:5.0.1-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:5.0-bionic-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/bionic/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:5.0-bionic-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:bionic-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/4.2.3/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/4.2.3/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:4.2.3-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/4.2.3/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/4.2.3/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:4.2.3-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/5.0.1/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:5.0.1-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/5.0.1/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/5.0.1/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:5.0.1-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/5.0/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/5.0/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:5.0-xenial-build
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial-build
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations

--- a/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/5.0/run/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3/ubuntu/xenial/5.0/run/Dockerfile
@@ -2,7 +2,7 @@
 
 # wlisac/raspberrypi3-ubuntu-swift:5.0-xenial-run
 
-ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial
+ARG BASE_IMAGE=balenalib/raspberrypi3-ubuntu:xenial-run
 
 # Download and decompress the tarball into an intermediate container
 # to improve cache accross different base image variations
@@ -22,7 +22,7 @@ RUN curl -L -o $TARBALL_FILE $TARBALL_URL \
 
 # Create base image
 
-FROM $BASE_IMAGE-run
+FROM "$BASE_IMAGE"
 
 LABEL maintainer "Will Lisac <will@lisac.org>"
 LABEL Description="Docker Container for Swift on Balena"

--- a/Sources/SwiftOnBalena/ImageDescription.swift
+++ b/Sources/SwiftOnBalena/ImageDescription.swift
@@ -62,7 +62,7 @@ extension ImageDescription {
     }
     
     var balenaFromDockerTag: String {
-        return "balenalib/\(base.name)-\(operatingSystem.name):\(operatingSystem.version)"
+        return "balenalib/\(base.name)-\(operatingSystem.name):\(operatingSystem.version)-\(buildVariant.rawValue)"
     }
     
     func folder(createIfNeeded: Bool = false) throws -> Folder {


### PR DESCRIPTION
This fixes a mistake where only architecture-based `build` image variants were starting from balena's `build` image variant. The device-based images were starting from the default `run` variant. Now all `build` variants correctly start from the balena `build` variant.

This also unifies how the base image is specified for both `run` and `build` variants and updates the CLI automation to handle these changes.