### PR TITLE
Update Swift 5.0.1 images for aarch64 to support `--jobs` flag

### DIFF
--- a/Dockerfiles/architecture-base/aarch64/ubuntu/bionic/5.0.1/build/Dockerfile
+++ b/Dockerfiles/architecture-base/aarch64/ubuntu/bionic/5.0.1/build/Dockerfile
@@ -9,7 +9,7 @@ FROM balenalib/aarch64-ubuntu:bionic as downloader
 
 LABEL Description="Swift Downloader"
 
-ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-18.04_2019-05-17.tar.gz
+ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-18.04-patched_2019-07-03.tar.gz
 ARG TARBALL_FILE=swift.tgz
 
 WORKDIR /swift

--- a/Dockerfiles/architecture-base/aarch64/ubuntu/xenial/5.0.1/build/Dockerfile
+++ b/Dockerfiles/architecture-base/aarch64/ubuntu/xenial/5.0.1/build/Dockerfile
@@ -9,7 +9,7 @@ FROM balenalib/aarch64-ubuntu:xenial as downloader
 
 LABEL Description="Swift Downloader"
 
-ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-16.04_2019-04-24.tar.gz
+ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-16.04-patched_2019-07-03.tar.gz
 ARG TARBALL_FILE=swift.tgz
 
 WORKDIR /swift

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/bionic/5.0.1/build/Dockerfile
@@ -11,7 +11,7 @@ FROM balenalib/aarch64-ubuntu:bionic as downloader
 
 LABEL Description="Swift Downloader"
 
-ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-18.04_2019-05-17.tar.gz
+ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-18.04-patched_2019-07-03.tar.gz
 ARG TARBALL_FILE=swift.tgz
 
 WORKDIR /swift

--- a/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/generic-aarch64/ubuntu/xenial/5.0.1/build/Dockerfile
@@ -11,7 +11,7 @@ FROM balenalib/aarch64-ubuntu:xenial as downloader
 
 LABEL Description="Swift Downloader"
 
-ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-16.04_2019-04-24.tar.gz
+ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-16.04-patched_2019-07-03.tar.gz
 ARG TARBALL_FILE=swift.tgz
 
 WORKDIR /swift

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/bionic/5.0.1/build/Dockerfile
@@ -11,7 +11,7 @@ FROM balenalib/aarch64-ubuntu:bionic as downloader
 
 LABEL Description="Swift Downloader"
 
-ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-18.04_2019-05-17.tar.gz
+ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-18.04-patched_2019-07-03.tar.gz
 ARG TARBALL_FILE=swift.tgz
 
 WORKDIR /swift

--- a/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0.1/build/Dockerfile
+++ b/Dockerfiles/device-base/raspberrypi3-64/ubuntu/xenial/5.0.1/build/Dockerfile
@@ -11,7 +11,7 @@ FROM balenalib/aarch64-ubuntu:xenial as downloader
 
 LABEL Description="Swift Downloader"
 
-ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-16.04_2019-04-24.tar.gz
+ARG TARBALL_URL=https://github.com/futurejones/swift-arm64/releases/download/v5.0.1-RELEASE/swift-5.0.1-aarch64-RELEASE-Ubuntu-16.04-patched_2019-07-03.tar.gz
 ARG TARBALL_FILE=swift.tgz
 
 WORKDIR /swift


### PR DESCRIPTION
This updates the aarch64 Swift 5.0.1 images to use a patched Swift binary that was released today by @futurejones: https://github.com/futurejones/swift-arm64/releases/tag/v5.0.1-RELEASE

This "patched" version includes the `-j` / `--jobs` build option to limit the number of threads used by the Swift Package Manager. See more details about this option at https://github.com/apple/swift-package-manager/pull/2127.

Using this option is recommended when building on Raspberry Pi hardware:
```
swift build --jobs 1
```

The armv7 and armv6 based images for Swift 5.0.1 already included this patch: https://github.com/uraimo/buildSwiftOnARM/releases/tag/5.0.1